### PR TITLE
Updated to support UE5.2

### DIFF
--- a/Plugins/Stereolabs/Source/EnvironmentalLighting/Private/Core/EnvironmentalLightingManager.cpp
+++ b/Plugins/Stereolabs/Source/EnvironmentalLighting/Private/Core/EnvironmentalLightingManager.cpp
@@ -14,12 +14,12 @@
 //);
 
 AEnvironmentalLightingManager::AEnvironmentalLightingManager()
-	:
-	Batch(nullptr),
-	LeftEyeTexture(nullptr),
-	Light(nullptr),
-	EnvironmentalLightingIntensity(1.0f),
-	bEnableEnvironmentalLighting(true)
+	: 
+	Light( nullptr ),
+	bEnableEnvironmentalLighting( true ),
+	EnvironmentalLightingIntensity( 1.0f ),
+	LeftEyeTexture( nullptr ),
+	Batch( nullptr )
 {
 	PrimaryActorTick.bCanEverTick = true;
 }

--- a/Plugins/Stereolabs/Source/SpatialMapping/Private/Core/SpatialMappingManager.cpp
+++ b/Plugins/Stereolabs/Source/SpatialMapping/Private/Core/SpatialMappingManager.cpp
@@ -7,12 +7,12 @@
 
 ASpatialMappingManager::ASpatialMappingManager()
 	:
-	MeshFileFormat(ESlMeshFileFormat::MFF_OBJ),
-	bStepFailed(false),
-	SpatialMappingWorker(nullptr),
-	UpdateTime(0.0f),
-	bSpatialMappingPaused(false),
-	bShowMesh(true)
+	MeshFileFormat( ESlMeshFileFormat::MFF_OBJ ),
+	bShowMesh( true ),
+	bStepFailed( false ),
+	SpatialMappingWorker( nullptr ),
+	UpdateTime( 0.0f ),
+	bSpatialMappingPaused( false )
 {
 	PrimaryActorTick.bCanEverTick = true;
 	PrimaryActorTick.TickGroup = ETickingGroup::TG_PrePhysics;

--- a/Plugins/Stereolabs/Source/SpatialMapping/Private/Threading/SpatialMappingCubemapRunnable.cpp
+++ b/Plugins/Stereolabs/Source/SpatialMapping/Private/Threading/SpatialMappingCubemapRunnable.cpp
@@ -88,7 +88,7 @@ void FSpatialMappingCubemapRunnable::GetPixels()
 			break;
 	}
 
-	FTextureRenderTargetCubeResource* CubeResource = (FTextureRenderTargetCubeResource*)static_cast<FTextureRenderTargetResource*>(CubemapProxy->TextureTarget->Resource);
+	FTextureRenderTargetCubeResource* CubeResource = (FTextureRenderTargetCubeResource*)static_cast<FTextureRenderTargetResource*>(CubemapProxy->TextureTarget->GetResource());
 
 	if (CubeResource && TextureFormat != TSF_Invalid)
 	{
@@ -154,18 +154,19 @@ void FSpatialMappingCubemapRunnable::ConverToTextureCube()
 
 			int32 MipSize = CalculateImageBytes(CubemapProxy->TextureTarget->SizeX, CubemapProxy->TextureTarget->SizeX, 0, PixelFormat);
 
-			if (CubemapProxy->Cubemap->PlatformData)
+			if (CubemapProxy->Cubemap->GetPlatformData())
 			{
-				delete CubemapProxy->Cubemap->PlatformData;
+				delete CubemapProxy->Cubemap->GetPlatformData();
+				CubemapProxy->Cubemap->SetPlatformData( nullptr );
 			}
 
-			CubemapProxy->Cubemap->PlatformData = new FTexturePlatformData();
-			CubemapProxy->Cubemap->PlatformData->SizeX = CubemapProxy->TextureTarget->SizeX;
-			CubemapProxy->Cubemap->PlatformData->SizeY = CubemapProxy->TextureTarget->SizeX;
-			CubemapProxy->Cubemap->PlatformData->PixelFormat = PixelFormat;
+			CubemapProxy->Cubemap->SetPlatformData( new FTexturePlatformData() );
+			CubemapProxy->Cubemap->GetPlatformData()->SizeX = CubemapProxy->TextureTarget->SizeX;
+			CubemapProxy->Cubemap->GetPlatformData()->SizeY = CubemapProxy->TextureTarget->SizeX;
+			CubemapProxy->Cubemap->GetPlatformData()->PixelFormat = PixelFormat;
 
 			{
-				FTexture2DMipMap* Mip = new(CubemapProxy->Cubemap->PlatformData->Mips) FTexture2DMipMap();
+				FTexture2DMipMap* Mip = new FTexture2DMipMap(CubemapProxy->Cubemap->GetPlatformData()->Mips[0]);
 				Mip->SizeX = CubemapProxy->TextureTarget->SizeX;
 				Mip->SizeY = CubemapProxy->TextureTarget->SizeX;
 				Mip->BulkData.Lock(LOCK_READ_WRITE);
@@ -173,7 +174,7 @@ void FSpatialMappingCubemapRunnable::ConverToTextureCube()
 				Mip->BulkData.Unlock();
 			}
 
-			FTexture2DMipMap& Mip = CubemapProxy->Cubemap->PlatformData->Mips[0];
+			FTexture2DMipMap& Mip = CubemapProxy->Cubemap->GetPlatformData()->Mips[0];
 			uint8* SliceData = (uint8*)Mip.BulkData.Lock(LOCK_READ_WRITE);
 			
 			switch (TextureFormat)

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsBaseTypes.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsBaseTypes.cpp
@@ -9,9 +9,9 @@ FSlSpatialMappingParameters::FSlSpatialMappingParameters()
 	MaxMemoryUsage(2048),
 	PresetResolution(ESlSpatialMappingResolution::SMR_Medium),
 	PresetRange(ESlSpatialMappingRange::SMR_Auto),
-	bSaveTexture(false)/*,
+	StabilityCounter(0)/*,
 	bUseChunkOnly(bUseChunkOnly)*/,
-	StabilityCounter(0)
+	bSaveTexture(false)
 {
 	MaxRange = sl::SpatialMappingParameters::get(sl::unreal::ToSlType(PresetRange));
 	Resolution = sl::SpatialMappingParameters::get(sl::unreal::ToSlType(PresetResolution));

--- a/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsBaseTypes.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsBaseTypes.h
@@ -882,13 +882,18 @@ struct STEREOLABS_API FSlBody18Bone
 	GENERATED_BODY()
 
 	FSlBody18Bone()
-	{}
+		: 
+		FSlBody18Bone(ESlBody18Parts::LEFT_ANKLE,
+						 ESlBody18Parts::LEFT_KNEE)
+	{
+	};
 
 	FSlBody18Bone(ESlBody18Parts first, ESlBody18Parts second)
+		:
+		FirstEnd(first),
+		SecondEnd(second)
 	{
-		FirstEnd = first;
-		SecondEnd = second;
-	}
+	};
 
 	/** First end of the bone */
 	UPROPERTY(BlueprintReadOnly)
@@ -909,14 +914,19 @@ struct STEREOLABS_API FSlBody34Bone
 {
 	GENERATED_BODY()
 
-		FSlBody34Bone()
-	{}
+	FSlBody34Bone()
+		: 
+		FSlBody34Bone(ESlBody34Parts::LEFT_ANKLE,
+					 ESlBody34Parts::LEFT_KNEE)
+	{
+	};
 
 	FSlBody34Bone(ESlBody34Parts first, ESlBody34Parts second)
+		:
+		FirstEnd(first),
+		SecondEnd(second)
 	{
-		FirstEnd = first;
-		SecondEnd = second;
-	}
+	};
 
 	/** First end of the bone */
 	UPROPERTY(BlueprintReadOnly)
@@ -936,14 +946,19 @@ struct STEREOLABS_API FSlBody38Bone
 {
 	GENERATED_BODY()
 
-		FSlBody38Bone()
-	{}
+	FSlBody38Bone()
+		:
+		FSlBody38Bone(ESlBody38Parts::LEFT_ANKLE,
+						 ESlBody38Parts::LEFT_KNEE)
+	{
+	};
 
 	FSlBody38Bone(ESlBody38Parts first, ESlBody38Parts second)
+		:
+		FirstEnd(first),
+		SecondEnd(second)
 	{
-		FirstEnd = first;
-		SecondEnd = second;
-	}
+	};
 
 	/** First end of the bone */
 	UPROPERTY(BlueprintReadOnly)
@@ -965,13 +980,18 @@ struct STEREOLABS_API FSlBody70Bone
 {
 	GENERATED_BODY()
 
-		FSlBody70Bone()
-	{}
+	FSlBody70Bone()
+		:
+		FSlBody70Bone(ESlBody70Parts::LEFT_ANKLE,
+						 ESlBody70Parts::LEFT_KNEE)
+	{
+	}
 
 	FSlBody70Bone(ESlBody70Parts first, ESlBody70Parts second)
+		:
+		FirstEnd(first),
+		SecondEnd(second)
 	{
-		FirstEnd = first;
-		SecondEnd = second;
 	}
 
 	/** First end of the bone */
@@ -1122,7 +1142,8 @@ struct STEREOLABS_API FSlCameraInformation
 		SerialNumber(0),
 		CameraFirmwareVersion(0),
 		SensorsFirmwareVersion(0),
-		CameraModel(ESlModel::M_Unknown)
+		CameraModel(ESlModel::M_Unknown),
+		Resolution(FInt32Point::NoneValue)
 	{
 	}
 
@@ -2247,12 +2268,12 @@ struct STEREOLABS_API FSlInitParameters
 		VerticalFlipImage(ESlFlipMode::FP_AUTO),
 		bEnableRightSideMeasure(false),
 		DepthStabilization(1),
+		bAsyncGrabCameraRecovery(false),
 		OptionalSettingPath(""),
 		OptionalOpencvCalibrationFile(""),
 		bSensorsRequired(false),
 		bEnableImageEnhancement(true),
 		OpenTimeoutSec(5.0f),
-		bAsyncGrabCameraRecovery(false),
 		VerboseFilePath(""),
 		GrabComputeCappingFPS(0.0f)
 	{
@@ -2866,7 +2887,26 @@ struct STEREOLABS_API FSlObjectData
 {
 	GENERATED_BODY()
 
-	const TCHAR* Section = TEXT("ObjectData");
+	FSlObjectData()
+		:
+		Section( TEXT( "ObjectData" ) ),
+		Id( 0 ),
+		UniqueObjectId( "" ),
+		RawLabel( 0 ),
+		Label( ESlObjectClass::OC_ANIMAL ),
+		Sublabel( ESlObjectSubClass::OSC_APPLE ),
+		TrackingState( ESlObjectTrackingState::OTS_Off ),
+		ActionState( ESlObjectActionState::OAS_Idle ),
+		Position( FVector::ZeroVector ),
+		Velocity( FVector::ZeroVector ),
+		Mask(),
+		Confidence( 0.f ),
+		Dimensions( FVector::ZeroVector ),
+		HeadPosition( FVector::ZeroVector )
+	{
+	};
+
+	const TCHAR* Section;
 
 	/* Object identification number, used as a reference when tracking the object through the frames.*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
@@ -3093,7 +3133,24 @@ struct STEREOLABS_API FSlBodyData
 {
 	GENERATED_BODY()
 
-	const TCHAR* Section = TEXT("BodyData");
+	FSlBodyData()
+		:
+		Section( TEXT( "BodyData" ) ),
+		Id( 0 ),
+		UniqueObjectId( "" ),
+		TrackingState( ESlObjectTrackingState::OTS_Off ),
+		ActionState( ESlObjectActionState::OAS_Idle ),
+		Position( FVector::ZeroVector ),
+		Velocity( FVector::ZeroVector ),
+		Mask(),
+		Confidence( 0.f ),
+		Dimensions( FVector::ZeroVector ),
+		HeadPosition( FVector::ZeroVector ),
+		GlobalRootOrientation( EForceInit::ForceInit )
+	{
+	};
+
+	const TCHAR* Section;
 
 	/* Object identification number, used as a reference when tracking the object through the frames.*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/Plugins/Stereolabs/Source/ZED/Private/Core/AnimNode_ZEDPose.cpp
+++ b/Plugins/Stereolabs/Source/ZED/Private/Core/AnimNode_ZEDPose.cpp
@@ -372,7 +372,27 @@ void FAnimNode_ZEDPose::BuildPoseFromSlBodyData(FPoseContext& PoseContext)
         PropagateRestPoseRotations(0, OutPose, OutPose.GetRefPose(CPIndexRoot).GetRotation().Inverse(), true);
 }
 
-FAnimNode_ZEDPose::FAnimNode_ZEDPose(): PrevDataInitialized(false)
+FAnimNode_ZEDPose::FAnimNode_ZEDPose()
+	:
+ 	bMirrorOnZAxis( false ),
+	ManualHeightOffset( -1.f ),
+	bStickAvatarOnFloor( false ),
+	bEnableBoneScaling( false ),
+	RotationSlerpIntensity( -1.f ),
+	RootLocationSlerpIntensity( FVector::ZeroVector ),
+	SkeletalMesh( nullptr ),
+	NbKeypoints( -1 ),
+	BoneScaleAlpha( 0.2f ),
+	DurationOffsetErrorThreshold( 3.0f ),
+	DurationOffsetError( 0.f ),
+	PreviousTS_ms( 0 ),
+	DistanceToFloorThreshold( 0.f ),
+	AutomaticHeightOffset( 0.f ),
+	LeftAnkleToHeelOffset( 0.f ),
+	RightAnkleToHeelOffset( 0.f ),
+	PreviousRootPosition( FVector::ZeroVector ),
+	PreviousRootRotation( EForceInit::ForceInit ),
+	PrevDataInitialized( false )
 {
 }
 

--- a/Plugins/Stereolabs/Source/ZED/Private/Core/ZEDCamera.cpp
+++ b/Plugins/Stereolabs/Source/ZED/Private/Core/ZEDCamera.cpp
@@ -33,12 +33,20 @@ AZEDCamera::AZEDCamera()
 	LeftEyeColor(nullptr),
 	LeftEyeDepth(nullptr),
 	LeftEyeRenderTarget(nullptr),
-	Batch(nullptr),
-	CurrentDepthTextureQualityPreset(1),
-	bCurrentDepthEnabled(false),
-	bInit(false),
-	bShowZedImage(true),
-	ImageView(ESlView::V_Left)
+	ImageView( ESlView::V_Left ),
+	CameraRenderPlaneDistance( 0.f ),
+	ZedLeftEyeMaterialInstanceDynamic( nullptr ),
+	bDepthOcclusion( true ),
+	DepthClampThreshold( 0.f ),
+	Batch( nullptr ),
+	ZedSourceMaterial( nullptr ),
+	CurrentDepthTextureQualityPreset( 1 ),
+	bCurrentDepthEnabled( false ),
+	bInit( false ),
+	bShowZedImage( true ),
+	LeftRoot( nullptr ),
+	LeftCamera( nullptr ),
+	LeftPlane( nullptr )
 {
 	// Controller tick the camera to make it the first actor to tick
 	PrimaryActorTick.bCanEverTick = false;

--- a/Plugins/Stereolabs/Source/ZED/Private/Core/ZEDInitializer.cpp
+++ b/Plugins/Stereolabs/Source/ZED/Private/Core/ZEDInitializer.cpp
@@ -27,11 +27,12 @@ bool CheckGConfigAvailable()
 
 AZEDInitializer::AZEDInitializer()
 	:
+	ImageView(ESlView::V_Left),
 	bLoadParametersFromConfigFile(false),
 	bLoadCameraSettingsFromConfigFile(false),
 	bDepthOcclusion(true),
 	bShowZedImage(true),
-	ImageView(ESlView::V_Left)
+	DepthClampThreshold(0.f)
 {
 	if (InitParameters.VerboseFilePath.IsEmpty())
 	{

--- a/Plugins/Stereolabs/Source/ZED/Private/Core/ZEDPawn.cpp
+++ b/Plugins/Stereolabs/Source/ZED/Private/Core/ZEDPawn.cpp
@@ -8,19 +8,34 @@
 
 #include "Stereolabs/Public/Utilities/StereolabsFunctionLibrary.h"
 
-AZEDPawn::AZEDPawn() :
+AZEDPawn::AZEDPawn()
+	:
+	SpringArm(nullptr),
+	Camera(nullptr),
 	EnableLerp(true),
-	LerpIntensity(10.0),
-	IsFrozen(false),
+	LerpIntensity(10.0f),
+	LerpTransform(),
 	ToggleFreeze(false),
 	UseRotationOffset(true),
+	IsFrozen(false),
 	StartOffsetLocation(FVector::ZeroVector),
 	SetFloorAsOriginCorrected(false),
 	PreviousLocation(FVector::ZeroVector),
 	PreviousToCurrentLocation(FVector::ZeroVector),
 	TranslationMultiplier(FVector::OneVector),
 	VirtualLocation(FVector::ZeroVector),
-	PrevVirtualLocation(FVector::ZeroVector)
+	PrevVirtualLocation(FVector::ZeroVector),
+	ZedLoadingWidget(nullptr),
+	ZedErrorWidget(nullptr),
+	RemapSourceMaterial(nullptr),
+	RemapMaterialInstanceDynamic(nullptr),
+	RemapMx(nullptr),
+	RemapMy(nullptr),
+	ZedLoadingSourceWidget(nullptr),
+	ZedErrorSourceWidget(nullptr),
+	ZedWidgetSourceMaterial(nullptr),
+	TransformOffset(),
+	RealCameraTransform()
 {
 	TransformOffset = FTransform();
 	ToggleFreeze = false;

--- a/Plugins/Stereolabs/Source/ZED/Public/Core/ZEDCamera.h
+++ b/Plugins/Stereolabs/Source/ZED/Public/Core/ZEDCamera.h
@@ -302,7 +302,7 @@ public:
 	
 	/** When enabled, the real world can occlude (cover up) virtual objects that are behind it. Otherwise, virtual objects will appear in front. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Zed")
-	uint8 bDepthOcclusion : 1;
+	bool bDepthOcclusion;
 
 	/** Max depth distance. Can be modified at runtime */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Zed")
@@ -337,12 +337,12 @@ private:
 	int32 CurrentDepthTextureQualityPreset;
 
 	/** True if depth enabled */
-	uint8 bCurrentDepthEnabled:1;
+	bool bCurrentDepthEnabled;
 
 	/** True if initialized */
-	uint8 bInit:1;
+	bool bInit;
 
-	uint8 bShowZedImage:1;
+	bool bShowZedImage;
 
 	/************************ Section from old blueprint **********************/
 

--- a/Plugins/Stereolabs/Source/ZED/Public/Core/ZEDInitializer.h
+++ b/Plugins/Stereolabs/Source/ZED/Public/Core/ZEDInitializer.h
@@ -121,17 +121,17 @@ public:
 
 	/** Load parameters at runtime from config file and override preset */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Zed")
-	uint8 bLoadParametersFromConfigFile:1;
+	bool bLoadParametersFromConfigFile;
 
 	/** Load camera settings at runtime from config file and override preset  */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Zed")
-	uint8 bLoadCameraSettingsFromConfigFile:1;
+	bool bLoadCameraSettingsFromConfigFile;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Zed")
-	uint8 bDepthOcclusion : 1;
+	bool bDepthOcclusion;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Zed")
-	uint8 bShowZedImage : 1;
+	bool bShowZedImage;
 
 	/*
 	* Can be used for Background substaction application.


### PR DESCRIPTION
Changed use of uint8 to bool, fixing compiler warnings for conversion.
Added constructors to structs where there weren't any.
Updated Constructor initialisation lists to be complete to matching properties and reordered where properties were warned against being initialized after others.
Added use of Texture/Material Getters and Setters.
Fixed getting of D3D Native Resource (in StereolabsTexture.cpp). This accompanies the change in the D3D RHI in UE5.2 update.