### PR TITLE
Fix access violation in `USlTexture::BeginDestroy`

### DIFF
--- a/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsTexture.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsTexture.h
@@ -122,9 +122,6 @@ public:
 	/** Cuda resource used for copying from SDK to render API */
 	cudaGraphicsResource_t CudaResource;
 
-	// Ptr used when cuda interop is not used (for ex : when using DX12).
-	void* MatPtr;
-
 	bool bCudaInteropEnabled;
 protected:
 	/** Type of memory used to access the texture */


### PR DESCRIPTION
I had been encountering an access violation from `USlTexture::BeginDestroy` when attempting to free `MatPtr`. Upon digging in, I realised that while `MatPtr` is pointed to a block of allocated memory in `InitResources`, `MatPtr` is then overwritten in `UpdateTexture` (also leaking the original block of memory). Then in shutdown, `MatPtr` is attempted to be freed nevertheless - even though we do not have ownership of the data it is now pointing to.

The copying of data in `InitResources` also appears to be redundant - it seems to just be copying uninitialized memory from one buffer to another.

Overall, there does not appear to be any need for `MatPtr` to live outside the scope of the `UpdateTexture` functions, and that keeps things simple for managing lifetimes also.