### PR TITLE
Implemented D3D12-CUDA interop

### DIFF
--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.cpp
@@ -1,0 +1,466 @@
+//======= Copyright (c) Stereolabs Corporation, All rights reserved. ===============
+
+#include "StereolabsCudaInterop.h"
+
+#include "ID3D11DynamicRHI.h"
+#include "ID3D12DynamicRHI.h"
+#include "D3D11RHI.h"
+#include "D3D11Util.h"
+#include "RHICommandList.h"
+#include "RHIDefinitions.h"
+
+#include "Utilities/StereolabsMatFunctionLibrary.h"
+
+#include "Windows/AllowWindowsPlatformTypes.h" 
+#include <cuda_d3d11_interop.h>
+
+#include <aclapi.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+
+THIRD_PARTY_INCLUDES_START
+#include <d3d12.h>
+THIRD_PARTY_INCLUDES_END
+
+
+struct ScopedCudaContext
+{
+	ScopedCudaContext()
+	{
+		if (GSlCameraProxy)
+			GSlCameraProxy->PushCudaContext();
+	}
+	~ScopedCudaContext()
+	{
+		if (GSlCameraProxy)
+			GSlCameraProxy->PopCudaContext();
+	}
+};
+
+
+// D3D11 IMPLEMENTATION
+
+void IStereolabsCudaInteropSyncPoint::SyncCudaToGraphics(const IStereolabsCudaInterop* Resource,
+	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	TArrayView<const IStereolabsCudaInterop*> ResourceArray( &Resource, 1 );
+	SyncCudaToGraphics(ResourceArray, RHICmdList, Stream);
+}
+
+void IStereolabsCudaInteropSyncPoint::SyncGraphicsToCuda(const IStereolabsCudaInterop* Resource,
+	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	TArrayView<const IStereolabsCudaInterop*> ResourceArray( &Resource, 1 );
+	SyncGraphicsToCuda(ResourceArray, RHICmdList, Stream);
+}
+
+FStereolabsCudaInteropD3D11::FStereolabsCudaInteropD3D11(FTextureRHIRef TextureRHI)
+{
+	check(TextureRHI);
+	ScopedCudaContext CudaContext;
+
+	ID3D11Resource* D3D11NativeTexture = GetID3D11DynamicRHI()->RHIGetResource(TextureRHI);
+	cudaError CudaError = cudaGraphicsD3D11RegisterResource(&CudaResource, D3D11NativeTexture, cudaGraphicsMapFlagsNone);
+	check(CudaError == cudaSuccess);
+}
+
+FStereolabsCudaInteropD3D11::~FStereolabsCudaInteropD3D11()
+{
+	ScopedCudaContext CudaContext;
+
+	if (CudaResource)
+	{
+		cudaGraphicsUnregisterResource(CudaResource);
+	}
+}
+
+void FStereolabsCudaInteropD3D11::UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	ScopedCudaContext CudaContext;
+
+	check(IsInRenderingThread());
+
+	cudaArray_t Array = nullptr;
+	cudaError CudaError = cudaGraphicsSubResourceGetMappedArray(&Array, CudaResource, 0, 0);
+	check(CudaError == cudaSuccess);
+
+	SL_MEM MemType = static_cast<SL_MEM>(sl_mat_get_memory_type(Mat));
+	CudaError = cudaMemcpy2DToArrayAsync(
+		Array, 0, 0, 
+	sl_mat_get_ptr(Mat, MemType), sl_mat_get_step_bytes(Mat, MemType), sl_mat_get_width_bytes(Mat), sl_mat_get_height(Mat),
+	cudaMemcpyDeviceToDevice, Stream);
+	check(CudaError == cudaSuccess);
+}
+
+
+void FStereolabsCudaInteropSyncPointD3D11::SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources,
+	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	ScopedCudaContext CudaContext;
+
+	check(IsInRenderingThread());
+
+	TArray<cudaGraphicsResource_t> CudaResources;
+	CudaResources.Reserve(Resources.Num());
+	for (const IStereolabsCudaInterop* Resource : Resources)
+	{
+		CudaResources.Add(static_cast<const FStereolabsCudaInteropD3D11*>(Resource)->GetCudaResource());
+	}
+
+	cudaError CudaError = cudaGraphicsMapResources(Resources.Num(), CudaResources.GetData(), Stream);
+	check(CudaError == cudaSuccess);
+}
+
+void FStereolabsCudaInteropSyncPointD3D11::SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources,
+	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	ScopedCudaContext CudaContext;
+
+	check(IsInRenderingThread());
+
+	TArray<cudaGraphicsResource_t> CudaResources;
+	CudaResources.Reserve(Resources.Num());
+	for (const IStereolabsCudaInterop* Resource : Resources)
+	{
+		CudaResources.Add(static_cast<const FStereolabsCudaInteropD3D11*>(Resource)->GetCudaResource());
+	}
+
+	cudaError CudaError = cudaGraphicsUnmapResources(Resources.Num(), CudaResources.GetData(), Stream);
+	check(CudaError == cudaSuccess);
+}
+
+
+// D3D12 IMPLEMENTATION
+
+class FWindowsSecurityAttributes
+{
+protected:
+	SECURITY_ATTRIBUTES  m_winSecurityAttributes;
+	PSECURITY_DESCRIPTOR m_winPSecurityDescriptor;
+
+public:
+	FWindowsSecurityAttributes()
+	{
+		m_winPSecurityDescriptor = (PSECURITY_DESCRIPTOR)calloc(1, SECURITY_DESCRIPTOR_MIN_LENGTH + 2 * sizeof(void**));
+		check(m_winPSecurityDescriptor != (PSECURITY_DESCRIPTOR)NULL);
+
+		PSID* ppSID = (PSID*)((PBYTE)m_winPSecurityDescriptor + SECURITY_DESCRIPTOR_MIN_LENGTH);
+		PACL* ppACL = (PACL*)((PBYTE)ppSID + sizeof(PSID*));
+
+		InitializeSecurityDescriptor(m_winPSecurityDescriptor, SECURITY_DESCRIPTOR_REVISION);
+
+		SID_IDENTIFIER_AUTHORITY sidIdentifierAuthority = SECURITY_WORLD_SID_AUTHORITY;
+		AllocateAndInitializeSid(&sidIdentifierAuthority, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, ppSID);
+
+		EXPLICIT_ACCESS explicitAccess;
+		ZeroMemory(&explicitAccess, sizeof(EXPLICIT_ACCESS));
+		explicitAccess.grfAccessPermissions = STANDARD_RIGHTS_ALL | SPECIFIC_RIGHTS_ALL;
+		explicitAccess.grfAccessMode = SET_ACCESS;
+		explicitAccess.grfInheritance = INHERIT_ONLY;
+		explicitAccess.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+		explicitAccess.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+		explicitAccess.Trustee.ptstrName = (LPTSTR)*ppSID;
+
+		SetEntriesInAcl(1, &explicitAccess, NULL, ppACL);
+
+		SetSecurityDescriptorDacl(m_winPSecurityDescriptor, true, *ppACL, false);
+
+		m_winSecurityAttributes.nLength = sizeof(m_winSecurityAttributes);
+		m_winSecurityAttributes.lpSecurityDescriptor = m_winPSecurityDescriptor;
+		m_winSecurityAttributes.bInheritHandle = true;
+	}
+	~FWindowsSecurityAttributes()
+	{
+		PSID* ppSID = (PSID*)((PBYTE)m_winPSecurityDescriptor + SECURITY_DESCRIPTOR_MIN_LENGTH);
+		PACL* ppACL = (PACL*)((PBYTE)ppSID + sizeof(PSID*));
+
+		if (*ppSID) {
+			FreeSid(*ppSID);
+		}
+		if (*ppACL) {
+			LocalFree(*ppACL);
+		}
+		free(m_winPSecurityDescriptor);
+	}
+	SECURITY_ATTRIBUTES* operator&() { return &m_winSecurityAttributes; }
+};
+
+
+cudaChannelFormatDesc getCudaChannelFormatDescForDxgiFormat(DXGI_FORMAT dxgiFormat)
+{
+	cudaChannelFormatDesc d;
+
+	memset(&d, 0, sizeof(d));
+
+	switch (dxgiFormat) {
+	case DXGI_FORMAT_R8_UINT:            d.x = 8;  d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R8_SINT:            d.x = 8;  d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R8G8_UINT:          d.x = 8;  d.y = 8;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R8G8_SINT:          d.x = 8;  d.y = 8;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R8G8B8A8_UINT:      d.x = 8;  d.y = 8;  d.z = 8;  d.w = 8;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R8G8B8A8_SINT:      d.x = 8;  d.y = 8;  d.z = 8;  d.w = 8;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R8G8B8A8_UNORM:     d.x = 8;  d.y = 8;  d.z = 8;  d.w = 8;  d.f = cudaChannelFormatKindUnsignedNormalized8X4;  break;
+	case DXGI_FORMAT_R8G8B8A8_SNORM:     d.x = 8;  d.y = 8;  d.z = 8;  d.w = 8;  d.f = cudaChannelFormatKindSignedNormalized8X4;	break;
+	case DXGI_FORMAT_R16_UINT:           d.x = 16; d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R16_SINT:           d.x = 16; d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R16G16_UINT:        d.x = 16; d.y = 16; d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R16G16_SINT:        d.x = 16; d.y = 16; d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R16G16B16A16_UINT:  d.x = 16; d.y = 16; d.z = 16; d.w = 16; d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R16G16B16A16_SINT:  d.x = 16; d.y = 16; d.z = 16; d.w = 16; d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R32_UINT:           d.x = 32; d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R32_SINT:           d.x = 32; d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R32_FLOAT:          d.x = 32; d.y = 0;  d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindFloat;					break;
+	case DXGI_FORMAT_R32G32_UINT:        d.x = 32; d.y = 32; d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R32G32_SINT:        d.x = 32; d.y = 32; d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R32G32_FLOAT:       d.x = 32; d.y = 32; d.z = 0;  d.w = 0;  d.f = cudaChannelFormatKindFloat;					break;
+	case DXGI_FORMAT_R32G32B32A32_UINT:  d.x = 32; d.y = 32; d.z = 32; d.w = 32; d.f = cudaChannelFormatKindUnsigned;				break;
+	case DXGI_FORMAT_R32G32B32A32_SINT:  d.x = 32; d.y = 32; d.z = 32; d.w = 32; d.f = cudaChannelFormatKindSigned;					break;
+	case DXGI_FORMAT_R32G32B32A32_FLOAT: d.x = 32; d.y = 32; d.z = 32; d.w = 32; d.f = cudaChannelFormatKindFloat;					break;
+	default: check(false);
+	}
+	return d;
+}
+
+cudaExtent getCudaExtentForD3D12Extent(UINT64 width, UINT height, UINT16 depthOrArraySize, D3D12_SRV_DIMENSION d3d12SRVDimension) {
+	cudaExtent e = { 0, 0, 0 };
+
+	switch (d3d12SRVDimension) {
+	case D3D12_SRV_DIMENSION_TEXTURE1D:        e.width = width; e.height = 0;      e.depth = 0;                break;
+	case D3D12_SRV_DIMENSION_TEXTURE2D:        e.width = width; e.height = height; e.depth = 0;                break;
+	case D3D12_SRV_DIMENSION_TEXTURE3D:        e.width = width; e.height = height; e.depth = depthOrArraySize; break;
+	case D3D12_SRV_DIMENSION_TEXTURECUBE:      e.width = width; e.height = height; e.depth = depthOrArraySize; break;
+	case D3D12_SRV_DIMENSION_TEXTURE1DARRAY:   e.width = width; e.height = 0;      e.depth = depthOrArraySize; break;
+	case D3D12_SRV_DIMENSION_TEXTURE2DARRAY:   e.width = width; e.height = height; e.depth = depthOrArraySize; break;
+	case D3D12_SRV_DIMENSION_TEXTURECUBEARRAY: e.width = width; e.height = height; e.depth = depthOrArraySize; break;
+	default: check(false);
+	}
+
+	return e;
+}
+
+unsigned int getCudaMipmappedArrayFlagsForD3D12Resource(D3D12_SRV_DIMENSION d3d12SRVDimension, D3D12_RESOURCE_FLAGS d3d12ResourceFlags, bool allowSurfaceLoadStore) {
+	unsigned int flags = 0;
+
+	switch (d3d12SRVDimension) {
+	case D3D12_SRV_DIMENSION_TEXTURECUBE:      flags |= cudaArrayCubemap;                    break;
+	case D3D12_SRV_DIMENSION_TEXTURECUBEARRAY: flags |= cudaArrayCubemap | cudaArrayLayered; break;
+	case D3D12_SRV_DIMENSION_TEXTURE1DARRAY:   flags |= cudaArrayLayered;                    break;
+	case D3D12_SRV_DIMENSION_TEXTURE2DARRAY:   flags |= cudaArrayLayered;                    break;
+	default: break;
+	}
+
+	if (d3d12ResourceFlags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET) {
+		flags |= cudaArrayColorAttachment;
+	}
+	if (allowSurfaceLoadStore) {
+		flags |= cudaArraySurfaceLoadStore;
+	}
+
+	return flags;
+}
+
+
+FStereolabsCudaInteropD3D12::FStereolabsCudaInteropD3D12(FTextureRHIRef TextureRHI)
+	: OutputTexture(TextureRHI)
+{
+	ScopedCudaContext CudaContext;
+
+	check(TextureRHI);
+
+	bOutputTextureSupportsInterop = EnumHasAnyFlags(OutputTexture->GetDesc().Flags, TexCreate_Shared);
+
+	// D3D12 Interop textures must be created with TexCreate_Shared
+	if (!bOutputTextureSupportsInterop)
+	{
+		// Create the staging texture
+		ENQUEUE_RENDER_COMMAND(CreateSharedTexture)([this](FRHICommandListImmediate& CmdList)
+			{
+				FRHITextureCreateDesc Desc{
+					OutputTexture->GetDesc(),
+					ERHIAccess::SRVMask,
+					TEXT("StereolabsCudaInteropStagingTexture")
+				};
+				Desc.Flags |= TexCreate_Shared;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
+				FRHITextureInitializer TexInitializer = GDynamicRHI->RHICreateTextureInitializer(CmdList, Desc);
+				this->CudaInteropStagingTexture = TexInitializer.Finalize();
+#else
+				this->CudaInteropStagingTexture = GDynamicRHI->RHICreateTexture(CmdList, Desc);
+#endif
+			});
+
+		FlushRenderingCommands();
+	}
+
+	ID3D12DynamicRHI* D3D12RHI = GetID3D12DynamicRHI();
+	uint32 NodeMask = D3D12RHI->RHIGetDeviceNodeMask(0);
+
+	ID3D12Resource* D3D12NativeResource = D3D12RHI->RHIGetResource(bOutputTextureSupportsInterop ? OutputTexture : CudaInteropStagingTexture);
+
+	HANDLE SharedHandle;
+	FWindowsSecurityAttributes WindowsSecurityAttributes;
+	D3D12RHI->RHIGetDevice(0)->CreateSharedHandle(D3D12NativeResource, &WindowsSecurityAttributes, GENERIC_ALL, nullptr, &SharedHandle);
+
+	D3D12_RESOURCE_DESC ResourceDesc = D3D12NativeResource->GetDesc();
+	D3D12_RESOURCE_ALLOCATION_INFO ResourceAllocationInfo = D3D12RHI->RHIGetDevice(0)->GetResourceAllocationInfo(NodeMask, 1, &ResourceDesc);
+
+	cudaExternalMemoryHandleDesc ExternalMemoryDesc = {};
+	memset(&ExternalMemoryDesc, 0, sizeof(ExternalMemoryDesc));
+
+	ExternalMemoryDesc.type = cudaExternalMemoryHandleTypeD3D12Resource;
+	ExternalMemoryDesc.handle.win32.handle = SharedHandle;
+	ExternalMemoryDesc.size = ResourceAllocationInfo.SizeInBytes;
+	ExternalMemoryDesc.flags = cudaExternalMemoryDedicated;
+
+	cudaError_t CudaError = cudaImportExternalMemory(&CudaExternalMemory, &ExternalMemoryDesc);
+	check(CudaError == cudaSuccess);
+
+	cudaExternalMemoryMipmappedArrayDesc MipmappedArrayDesc = {};
+	memset(&MipmappedArrayDesc, 0, sizeof(MipmappedArrayDesc));
+
+	MipmappedArrayDesc.offset = 0;
+	MipmappedArrayDesc.formatDesc = getCudaChannelFormatDescForDxgiFormat(ResourceDesc.Format);
+	MipmappedArrayDesc.extent = getCudaExtentForD3D12Extent(ResourceDesc.Width, ResourceDesc.Height, ResourceDesc.DepthOrArraySize, D3D12_SRV_DIMENSION_TEXTURE2D);
+	MipmappedArrayDesc.flags = getCudaMipmappedArrayFlagsForD3D12Resource(D3D12_SRV_DIMENSION_TEXTURE2D, ResourceDesc.Flags, false);
+	MipmappedArrayDesc.numLevels = 1;
+
+	CudaError = cudaExternalMemoryGetMappedMipmappedArray(&CudaMipmappedArray, CudaExternalMemory, &MipmappedArrayDesc);
+	check(CudaError == cudaSuccess);
+
+	CloseHandle(SharedHandle);
+}
+
+FStereolabsCudaInteropD3D12::~FStereolabsCudaInteropD3D12()
+{
+	ScopedCudaContext CudaContext;
+
+	if (CudaMipmappedArray)
+	{
+		cudaFreeMipmappedArray(CudaMipmappedArray);
+	}
+	if (CudaExternalMemory)
+	{
+		cudaDestroyExternalMemory(CudaExternalMemory);
+	}
+}
+
+void FStereolabsCudaInteropD3D12::UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	ScopedCudaContext CudaContext;
+
+	check(IsInRenderingThread());
+
+	cudaArray_t LevelArray = nullptr;
+	cudaError CudaError = cudaGetMipmappedArrayLevel(&LevelArray, CudaMipmappedArray, 0);
+	check(CudaError == cudaSuccess);
+
+	SL_MEM MemType = static_cast<SL_MEM>(sl_mat_get_memory_type(Mat));
+	CudaError = cudaMemcpy2DToArrayAsync(
+		LevelArray, 0, 0,
+		sl_mat_get_ptr(Mat, MemType), sl_mat_get_step_bytes(Mat, MemType), sl_mat_get_width_bytes(Mat), sl_mat_get_height(Mat),
+		cudaMemcpyDeviceToDevice, Stream);
+	check(CudaError == cudaSuccess);
+
+	if (!bOutputTextureSupportsInterop)
+	{
+		FRHICopyTextureInfo CopyInfo{ };
+		RHICmdList.CopyTexture(CudaInteropStagingTexture, OutputTexture, CopyInfo);
+	}
+}
+
+
+FStereolabsCudaInteropSyncPointD3D12::FStereolabsCudaInteropSyncPointD3D12()
+{
+	ScopedCudaContext CudaContext;
+
+	ID3D12DynamicRHI* D3D12RHI = GetID3D12DynamicRHI();
+
+	// Create synchronization objects
+	D3D12RHI->RHIGetDevice(0)->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(Fence.GetInitReference()));
+
+	HANDLE SharedHandle;
+	FWindowsSecurityAttributes WindowsSecurityAttributes;
+	D3D12RHI->RHIGetDevice(0)->CreateSharedHandle(Fence.GetReference(), &WindowsSecurityAttributes, GENERIC_ALL, nullptr, &SharedHandle);
+
+	cudaExternalSemaphoreHandleDesc ExternalSemaphoreHandleDesc = {};
+
+	memset(&ExternalSemaphoreHandleDesc, 0, sizeof(ExternalSemaphoreHandleDesc));
+
+	ExternalSemaphoreHandleDesc.type = cudaExternalSemaphoreHandleTypeD3D12Fence;
+	ExternalSemaphoreHandleDesc.handle.win32.handle = SharedHandle;
+	ExternalSemaphoreHandleDesc.flags = 0;
+
+	cudaError CudaError = cudaImportExternalSemaphore(&CudaExternalSemaphore, &ExternalSemaphoreHandleDesc);
+	check(CudaError == cudaSuccess);
+
+	CloseHandle(SharedHandle);
+
+	// Set initial fence value
+	FenceValue = 1;
+}
+
+FStereolabsCudaInteropSyncPointD3D12::~FStereolabsCudaInteropSyncPointD3D12()
+{
+	ScopedCudaContext CudaContext;
+
+	if (CudaExternalSemaphore)
+	{
+		cudaDestroyExternalSemaphore(CudaExternalSemaphore);
+	}
+	if (Fence)
+	{
+		Fence->Release();
+		Fence.SafeRelease();
+	}
+}
+
+void FStereolabsCudaInteropSyncPointD3D12::SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources,
+	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	ScopedCudaContext CudaContext;
+
+	check(IsInRenderingThread());
+
+	// Signal fence
+	GetID3D12DynamicRHI()->RHIRunOnQueue(ED3D12RHIRunOnQueueType::Graphics, [this](ID3D12CommandQueue* Queue)
+		{
+			Queue->Signal(Fence, FenceValue);
+		}, true);
+
+	// Make cuda wait on signalled fence
+	cudaExternalSemaphoreWaitParams ExternalSemaphoreWaitParams = {};
+	memset(&ExternalSemaphoreWaitParams, 0, sizeof(ExternalSemaphoreWaitParams));
+
+	ExternalSemaphoreWaitParams.params.fence.value = FenceValue;
+	ExternalSemaphoreWaitParams.flags = 0;
+
+	cudaError CudaError = cudaWaitExternalSemaphoresAsync(&CudaExternalSemaphore, &ExternalSemaphoreWaitParams, 1, Stream);
+	check(CudaError == cudaSuccess);
+
+	FenceValue++;
+}
+
+void FStereolabsCudaInteropSyncPointD3D12::SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources,
+	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
+{
+	ScopedCudaContext CudaContext;
+
+	check(IsInRenderingThread());
+
+	// Signal fence
+	cudaExternalSemaphoreSignalParams ExternalSemaphoreSignalParams = {};
+	memset(&ExternalSemaphoreSignalParams, 0, sizeof(ExternalSemaphoreSignalParams));
+
+	ExternalSemaphoreSignalParams.params.fence.value = FenceValue;
+	ExternalSemaphoreSignalParams.flags = 0;
+
+	cudaError CudaError = cudaSignalExternalSemaphoresAsync(&CudaExternalSemaphore, &ExternalSemaphoreSignalParams, 1, Stream);
+	check(CudaError == cudaSuccess);
+
+	// Make graphics queue wait on signalled fence
+	GetID3D12DynamicRHI()->RHIRunOnQueue(ED3D12RHIRunOnQueueType::Graphics, [this](ID3D12CommandQueue* Queue)
+		{
+			Queue->Wait(Fence, FenceValue);
+		}, true);
+
+	FenceValue++;
+}

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.cpp
@@ -22,14 +22,14 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 
 
-struct ScopedCudaContext
+struct FScopedCudaContext
 {
-	ScopedCudaContext()
+	FScopedCudaContext()
 	{
 		if (GSlCameraProxy)
 			GSlCameraProxy->PushCudaContext();
 	}
-	~ScopedCudaContext()
+	~FScopedCudaContext()
 	{
 		if (GSlCameraProxy)
 			GSlCameraProxy->PopCudaContext();
@@ -56,7 +56,7 @@ void IStereolabsCudaInteropSyncPoint::SyncGraphicsToCuda(const IStereolabsCudaIn
 FStereolabsCudaInteropD3D11::FStereolabsCudaInteropD3D11(FTextureRHIRef TextureRHI)
 {
 	check(TextureRHI);
-	ScopedCudaContext CudaContext;
+	FScopedCudaContext CudaContext;
 
 	ID3D11Resource* D3D11NativeTexture = GetID3D11DynamicRHI()->RHIGetResource(TextureRHI);
 	cudaError CudaError = cudaGraphicsD3D11RegisterResource(&CudaResource, D3D11NativeTexture, cudaGraphicsMapFlagsNone);
@@ -65,19 +65,20 @@ FStereolabsCudaInteropD3D11::FStereolabsCudaInteropD3D11(FTextureRHIRef TextureR
 
 FStereolabsCudaInteropD3D11::~FStereolabsCudaInteropD3D11()
 {
-	ScopedCudaContext CudaContext;
+	FScopedCudaContext CudaContext;
 
 	if (CudaResource)
 	{
-		cudaGraphicsUnregisterResource(CudaResource);
+		cudaError CudaError = cudaGraphicsUnregisterResource(CudaResource);
+		check(CudaError == cudaSuccess);
 	}
 }
 
 void FStereolabsCudaInteropD3D11::UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
 {
-	ScopedCudaContext CudaContext;
-
 	check(IsInRenderingThread());
+
+	FScopedCudaContext CudaContext;
 
 	cudaArray_t Array = nullptr;
 	cudaError CudaError = cudaGraphicsSubResourceGetMappedArray(&Array, CudaResource, 0, 0);
@@ -95,9 +96,9 @@ void FStereolabsCudaInteropD3D11::UpdateTexture(void* Mat, FRHICommandListImmedi
 void FStereolabsCudaInteropSyncPointD3D11::SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources,
 	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
 {
-	ScopedCudaContext CudaContext;
-
 	check(IsInRenderingThread());
+
+	FScopedCudaContext CudaContext;
 
 	TArray<cudaGraphicsResource_t> CudaResources;
 	CudaResources.Reserve(Resources.Num());
@@ -113,9 +114,9 @@ void FStereolabsCudaInteropSyncPointD3D11::SyncCudaToGraphics(TArrayView<const I
 void FStereolabsCudaInteropSyncPointD3D11::SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources,
 	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
 {
-	ScopedCudaContext CudaContext;
-
 	check(IsInRenderingThread());
+
+	FScopedCudaContext CudaContext;
 
 	TArray<cudaGraphicsResource_t> CudaResources;
 	CudaResources.Reserve(Resources.Num());
@@ -262,7 +263,7 @@ unsigned int getCudaMipmappedArrayFlagsForD3D12Resource(D3D12_SRV_DIMENSION d3d1
 FStereolabsCudaInteropD3D12::FStereolabsCudaInteropD3D12(FTextureRHIRef TextureRHI)
 	: OutputTexture(TextureRHI)
 {
-	ScopedCudaContext CudaContext;
+	FScopedCudaContext CudaContext;
 
 	check(TextureRHI);
 
@@ -331,23 +332,25 @@ FStereolabsCudaInteropD3D12::FStereolabsCudaInteropD3D12(FTextureRHIRef TextureR
 
 FStereolabsCudaInteropD3D12::~FStereolabsCudaInteropD3D12()
 {
-	ScopedCudaContext CudaContext;
+	FScopedCudaContext CudaContext;
 
 	if (CudaMipmappedArray)
 	{
-		cudaFreeMipmappedArray(CudaMipmappedArray);
+		cudaError_t CudaError = cudaFreeMipmappedArray(CudaMipmappedArray);
+		check(CudaError == cudaSuccess);
 	}
 	if (CudaExternalMemory)
 	{
-		cudaDestroyExternalMemory(CudaExternalMemory);
+		cudaError_t CudaError = cudaDestroyExternalMemory(CudaExternalMemory);
+		check(CudaError == cudaSuccess);
 	}
 }
 
 void FStereolabsCudaInteropD3D12::UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
 {
-	ScopedCudaContext CudaContext;
-
 	check(IsInRenderingThread());
+
+	FScopedCudaContext CudaContext;
 
 	cudaArray_t LevelArray = nullptr;
 	cudaError CudaError = cudaGetMipmappedArrayLevel(&LevelArray, CudaMipmappedArray, 0);
@@ -370,7 +373,7 @@ void FStereolabsCudaInteropD3D12::UpdateTexture(void* Mat, FRHICommandListImmedi
 
 FStereolabsCudaInteropSyncPointD3D12::FStereolabsCudaInteropSyncPointD3D12()
 {
-	ScopedCudaContext CudaContext;
+	FScopedCudaContext CudaContext;
 
 	ID3D12DynamicRHI* D3D12RHI = GetID3D12DynamicRHI();
 
@@ -400,15 +403,15 @@ FStereolabsCudaInteropSyncPointD3D12::FStereolabsCudaInteropSyncPointD3D12()
 
 FStereolabsCudaInteropSyncPointD3D12::~FStereolabsCudaInteropSyncPointD3D12()
 {
-	ScopedCudaContext CudaContext;
+	FScopedCudaContext CudaContext;
 
 	if (CudaExternalSemaphore)
 	{
-		cudaDestroyExternalSemaphore(CudaExternalSemaphore);
+		cudaError CudaError = cudaDestroyExternalSemaphore(CudaExternalSemaphore);
+		check(CudaError == cudaSuccess);
 	}
 	if (Fence)
 	{
-		Fence->Release();
 		Fence.SafeRelease();
 	}
 }
@@ -416,9 +419,9 @@ FStereolabsCudaInteropSyncPointD3D12::~FStereolabsCudaInteropSyncPointD3D12()
 void FStereolabsCudaInteropSyncPointD3D12::SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources,
 	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
 {
-	ScopedCudaContext CudaContext;
-
 	check(IsInRenderingThread());
+
+	FScopedCudaContext CudaContext;
 
 	// Signal fence
 	GetID3D12DynamicRHI()->RHIRunOnQueue(ED3D12RHIRunOnQueueType::Graphics, [this](ID3D12CommandQueue* Queue)
@@ -442,9 +445,9 @@ void FStereolabsCudaInteropSyncPointD3D12::SyncCudaToGraphics(TArrayView<const I
 void FStereolabsCudaInteropSyncPointD3D12::SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources,
 	FRHICommandListImmediate& RHICmdList, cudaStream_t Stream)
 {
-	ScopedCudaContext CudaContext;
-
 	check(IsInRenderingThread());
+
+	FScopedCudaContext CudaContext;
 
 	// Signal fence
 	cudaExternalSemaphoreSignalParams ExternalSemaphoreSignalParams = {};

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.cpp
@@ -10,6 +10,7 @@
 #include "RHIDefinitions.h"
 
 #include "Utilities/StereolabsMatFunctionLibrary.h"
+#include "Core/StereolabsTexture.h"
 
 #include "Windows/AllowWindowsPlatformTypes.h" 
 #include <cuda_d3d11_interop.h>
@@ -21,6 +22,15 @@ THIRD_PARTY_INCLUDES_START
 #include <d3d12.h>
 THIRD_PARTY_INCLUDES_END
 
+
+static void CheckCudaError(cudaError_t result) {
+#if !UE_BUILD_SHIPPING
+	if (result) {
+		UE_LOG(SlTexture, Error, TEXT("CUDA error: %hs"), cudaGetErrorString(result));
+		check(false);
+	}
+#endif
+}
 
 struct FScopedCudaContext
 {
@@ -59,8 +69,7 @@ FStereolabsCudaInteropD3D11::FStereolabsCudaInteropD3D11(FTextureRHIRef TextureR
 	FScopedCudaContext CudaContext;
 
 	ID3D11Resource* D3D11NativeTexture = GetID3D11DynamicRHI()->RHIGetResource(TextureRHI);
-	cudaError CudaError = cudaGraphicsD3D11RegisterResource(&CudaResource, D3D11NativeTexture, cudaGraphicsMapFlagsNone);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaGraphicsD3D11RegisterResource(&CudaResource, D3D11NativeTexture, cudaGraphicsMapFlagsNone));
 }
 
 FStereolabsCudaInteropD3D11::~FStereolabsCudaInteropD3D11()
@@ -69,8 +78,7 @@ FStereolabsCudaInteropD3D11::~FStereolabsCudaInteropD3D11()
 
 	if (CudaResource)
 	{
-		cudaError CudaError = cudaGraphicsUnregisterResource(CudaResource);
-		check(CudaError == cudaSuccess);
+		CheckCudaError(cudaGraphicsUnregisterResource(CudaResource));
 	}
 }
 
@@ -81,15 +89,12 @@ void FStereolabsCudaInteropD3D11::UpdateTexture(void* Mat, FRHICommandListImmedi
 	FScopedCudaContext CudaContext;
 
 	cudaArray_t Array = nullptr;
-	cudaError CudaError = cudaGraphicsSubResourceGetMappedArray(&Array, CudaResource, 0, 0);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaGraphicsSubResourceGetMappedArray(&Array, CudaResource, 0, 0));
 
-	SL_MEM MemType = static_cast<SL_MEM>(sl_mat_get_memory_type(Mat));
-	CudaError = cudaMemcpy2DToArrayAsync(
+	CheckCudaError(cudaMemcpy2DToArrayAsync(
 		Array, 0, 0, 
-	sl_mat_get_ptr(Mat, MemType), sl_mat_get_step_bytes(Mat, MemType), sl_mat_get_width_bytes(Mat), sl_mat_get_height(Mat),
-	cudaMemcpyDeviceToDevice, Stream);
-	check(CudaError == cudaSuccess);
+		sl_mat_get_ptr(Mat, SL_MEM_GPU), sl_mat_get_step_bytes(Mat, SL_MEM_GPU), sl_mat_get_width_bytes(Mat), sl_mat_get_height(Mat),
+		cudaMemcpyDeviceToDevice, Stream));
 }
 
 
@@ -107,8 +112,7 @@ void FStereolabsCudaInteropSyncPointD3D11::SyncCudaToGraphics(TArrayView<const I
 		CudaResources.Add(static_cast<const FStereolabsCudaInteropD3D11*>(Resource)->GetCudaResource());
 	}
 
-	cudaError CudaError = cudaGraphicsMapResources(Resources.Num(), CudaResources.GetData(), Stream);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaGraphicsMapResources(Resources.Num(), CudaResources.GetData(), Stream));
 }
 
 void FStereolabsCudaInteropSyncPointD3D11::SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources,
@@ -125,13 +129,13 @@ void FStereolabsCudaInteropSyncPointD3D11::SyncGraphicsToCuda(TArrayView<const I
 		CudaResources.Add(static_cast<const FStereolabsCudaInteropD3D11*>(Resource)->GetCudaResource());
 	}
 
-	cudaError CudaError = cudaGraphicsUnmapResources(Resources.Num(), CudaResources.GetData(), Stream);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaGraphicsUnmapResources(Resources.Num(), CudaResources.GetData(), Stream));
 }
 
 
 // D3D12 IMPLEMENTATION
 
+// From simpleD3D12 CUDA sample (https://github.com/NVIDIA/cuda-samples/tree/master/Samples/5_Domain_Specific/simpleD3D12)
 class FWindowsSecurityAttributes
 {
 protected:
@@ -186,6 +190,7 @@ public:
 };
 
 
+// Modified from CUDA documentation (https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/graphics-interop.html#mapping-mipmapped-arrays-onto-imported-memory-objects-dir3d-12-int)
 cudaChannelFormatDesc getCudaChannelFormatDescForDxgiFormat(DXGI_FORMAT dxgiFormat)
 {
 	cudaChannelFormatDesc d;
@@ -221,6 +226,7 @@ cudaChannelFormatDesc getCudaChannelFormatDescForDxgiFormat(DXGI_FORMAT dxgiForm
 	return d;
 }
 
+// From CUDA documentation (https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/graphics-interop.html#mapping-mipmapped-arrays-onto-imported-memory-objects-dir3d-12-int)
 cudaExtent getCudaExtentForD3D12Extent(UINT64 width, UINT height, UINT16 depthOrArraySize, D3D12_SRV_DIMENSION d3d12SRVDimension) {
 	cudaExtent e = { 0, 0, 0 };
 
@@ -238,6 +244,7 @@ cudaExtent getCudaExtentForD3D12Extent(UINT64 width, UINT height, UINT16 depthOr
 	return e;
 }
 
+// From CUDA documentation (https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/graphics-interop.html#mapping-mipmapped-arrays-onto-imported-memory-objects-dir3d-12-int)
 unsigned int getCudaMipmappedArrayFlagsForD3D12Resource(D3D12_SRV_DIMENSION d3d12SRVDimension, D3D12_RESOURCE_FLAGS d3d12ResourceFlags, bool allowSurfaceLoadStore) {
 	unsigned int flags = 0;
 
@@ -312,8 +319,7 @@ FStereolabsCudaInteropD3D12::FStereolabsCudaInteropD3D12(FTextureRHIRef TextureR
 	ExternalMemoryDesc.size = ResourceAllocationInfo.SizeInBytes;
 	ExternalMemoryDesc.flags = cudaExternalMemoryDedicated;
 
-	cudaError_t CudaError = cudaImportExternalMemory(&CudaExternalMemory, &ExternalMemoryDesc);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaImportExternalMemory(&CudaExternalMemory, &ExternalMemoryDesc));
 
 	cudaExternalMemoryMipmappedArrayDesc MipmappedArrayDesc = {};
 	memset(&MipmappedArrayDesc, 0, sizeof(MipmappedArrayDesc));
@@ -324,8 +330,7 @@ FStereolabsCudaInteropD3D12::FStereolabsCudaInteropD3D12(FTextureRHIRef TextureR
 	MipmappedArrayDesc.flags = getCudaMipmappedArrayFlagsForD3D12Resource(D3D12_SRV_DIMENSION_TEXTURE2D, ResourceDesc.Flags, false);
 	MipmappedArrayDesc.numLevels = 1;
 
-	CudaError = cudaExternalMemoryGetMappedMipmappedArray(&CudaMipmappedArray, CudaExternalMemory, &MipmappedArrayDesc);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaExternalMemoryGetMappedMipmappedArray(&CudaMipmappedArray, CudaExternalMemory, &MipmappedArrayDesc));
 
 	CloseHandle(SharedHandle);
 }
@@ -336,13 +341,11 @@ FStereolabsCudaInteropD3D12::~FStereolabsCudaInteropD3D12()
 
 	if (CudaMipmappedArray)
 	{
-		cudaError_t CudaError = cudaFreeMipmappedArray(CudaMipmappedArray);
-		check(CudaError == cudaSuccess);
+		CheckCudaError(cudaFreeMipmappedArray(CudaMipmappedArray));
 	}
 	if (CudaExternalMemory)
 	{
-		cudaError_t CudaError = cudaDestroyExternalMemory(CudaExternalMemory);
-		check(CudaError == cudaSuccess);
+		CheckCudaError(cudaDestroyExternalMemory(CudaExternalMemory));
 	}
 }
 
@@ -353,15 +356,12 @@ void FStereolabsCudaInteropD3D12::UpdateTexture(void* Mat, FRHICommandListImmedi
 	FScopedCudaContext CudaContext;
 
 	cudaArray_t LevelArray = nullptr;
-	cudaError CudaError = cudaGetMipmappedArrayLevel(&LevelArray, CudaMipmappedArray, 0);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaGetMipmappedArrayLevel(&LevelArray, CudaMipmappedArray, 0));
 
-	SL_MEM MemType = static_cast<SL_MEM>(sl_mat_get_memory_type(Mat));
-	CudaError = cudaMemcpy2DToArrayAsync(
+	CheckCudaError(cudaMemcpy2DToArrayAsync(
 		LevelArray, 0, 0,
-		sl_mat_get_ptr(Mat, MemType), sl_mat_get_step_bytes(Mat, MemType), sl_mat_get_width_bytes(Mat), sl_mat_get_height(Mat),
-		cudaMemcpyDeviceToDevice, Stream);
-	check(CudaError == cudaSuccess);
+		sl_mat_get_ptr(Mat, SL_MEM_GPU), sl_mat_get_step_bytes(Mat, SL_MEM_GPU), sl_mat_get_width_bytes(Mat), sl_mat_get_height(Mat),
+		cudaMemcpyDeviceToDevice, Stream));
 
 	if (!bOutputTextureSupportsInterop)
 	{
@@ -385,15 +385,13 @@ FStereolabsCudaInteropSyncPointD3D12::FStereolabsCudaInteropSyncPointD3D12()
 	D3D12RHI->RHIGetDevice(0)->CreateSharedHandle(Fence.GetReference(), &WindowsSecurityAttributes, GENERIC_ALL, nullptr, &SharedHandle);
 
 	cudaExternalSemaphoreHandleDesc ExternalSemaphoreHandleDesc = {};
-
 	memset(&ExternalSemaphoreHandleDesc, 0, sizeof(ExternalSemaphoreHandleDesc));
 
 	ExternalSemaphoreHandleDesc.type = cudaExternalSemaphoreHandleTypeD3D12Fence;
 	ExternalSemaphoreHandleDesc.handle.win32.handle = SharedHandle;
 	ExternalSemaphoreHandleDesc.flags = 0;
 
-	cudaError CudaError = cudaImportExternalSemaphore(&CudaExternalSemaphore, &ExternalSemaphoreHandleDesc);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaImportExternalSemaphore(&CudaExternalSemaphore, &ExternalSemaphoreHandleDesc));
 
 	CloseHandle(SharedHandle);
 
@@ -407,8 +405,7 @@ FStereolabsCudaInteropSyncPointD3D12::~FStereolabsCudaInteropSyncPointD3D12()
 
 	if (CudaExternalSemaphore)
 	{
-		cudaError CudaError = cudaDestroyExternalSemaphore(CudaExternalSemaphore);
-		check(CudaError == cudaSuccess);
+		CheckCudaError(cudaDestroyExternalSemaphore(CudaExternalSemaphore));
 	}
 	if (Fence)
 	{
@@ -436,8 +433,7 @@ void FStereolabsCudaInteropSyncPointD3D12::SyncCudaToGraphics(TArrayView<const I
 	ExternalSemaphoreWaitParams.params.fence.value = FenceValue;
 	ExternalSemaphoreWaitParams.flags = 0;
 
-	cudaError CudaError = cudaWaitExternalSemaphoresAsync(&CudaExternalSemaphore, &ExternalSemaphoreWaitParams, 1, Stream);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaWaitExternalSemaphoresAsync(&CudaExternalSemaphore, &ExternalSemaphoreWaitParams, 1, Stream));
 
 	FenceValue++;
 }
@@ -456,8 +452,7 @@ void FStereolabsCudaInteropSyncPointD3D12::SyncGraphicsToCuda(TArrayView<const I
 	ExternalSemaphoreSignalParams.params.fence.value = FenceValue;
 	ExternalSemaphoreSignalParams.flags = 0;
 
-	cudaError CudaError = cudaSignalExternalSemaphoresAsync(&CudaExternalSemaphore, &ExternalSemaphoreSignalParams, 1, Stream);
-	check(CudaError == cudaSuccess);
+	CheckCudaError(cudaSignalExternalSemaphoresAsync(&CudaExternalSemaphore, &ExternalSemaphoreSignalParams, 1, Stream));
 
 	// Make graphics queue wait on signalled fence
 	GetID3D12DynamicRHI()->RHIRunOnQueue(ED3D12RHIRunOnQueueType::Graphics, [this](ID3D12CommandQueue* Queue)

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.h
@@ -1,0 +1,99 @@
+//======= Copyright (c) Stereolabs Corporation, All rights reserved. ===============
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include "RHIFwd.h"
+
+
+// Interface to abstract how different APIs interop with CUDA
+class IStereolabsCudaInterop
+{
+public:
+	IStereolabsCudaInterop() = default;
+	virtual ~IStereolabsCudaInterop() = default;
+
+	IStereolabsCudaInterop(const IStereolabsCudaInterop&) = delete;
+	IStereolabsCudaInterop& operator=(const IStereolabsCudaInterop&) = delete;
+
+	// Gives a pointer to a Cuda array to write to this resource (mip 0, array slice 0)
+	virtual void UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) = 0;
+};
+
+
+// Provides synchronization between CUDA and Graphics API
+// Allows for bulk synchronization of multiple resources to reduce overhead
+class IStereolabsCudaInteropSyncPoint
+{
+public:
+	IStereolabsCudaInteropSyncPoint() = default;
+	virtual ~IStereolabsCudaInteropSyncPoint() = default;
+
+	IStereolabsCudaInteropSyncPoint(const IStereolabsCudaInterop&) = delete;
+	IStereolabsCudaInteropSyncPoint& operator=(const IStereolabsCudaInteropSyncPoint&) = delete;
+
+	virtual void SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) = 0;
+	virtual void SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) = 0;
+
+	void SyncCudaToGraphics(const IStereolabsCudaInterop* Resource, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream);
+	void SyncGraphicsToCuda(const IStereolabsCudaInterop* Resource, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream);
+};
+
+
+class FStereolabsCudaInteropD3D11 final : public IStereolabsCudaInterop
+{
+public:
+	FStereolabsCudaInteropD3D11(FTextureRHIRef TextureRHI);
+	virtual ~FStereolabsCudaInteropD3D11();
+
+	virtual void UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
+
+	cudaGraphicsResource_t GetCudaResource() const { return CudaResource; }
+
+private:
+	cudaGraphicsResource_t CudaResource;
+
+};
+
+class FStereolabsCudaInteropSyncPointD3D11 final : public IStereolabsCudaInteropSyncPoint
+{
+public:
+	virtual void SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
+	virtual void SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
+};
+
+
+class FStereolabsCudaInteropD3D12 final : public IStereolabsCudaInterop
+{
+public:
+	FStereolabsCudaInteropD3D12(FTextureRHIRef TextureRHI);
+	virtual ~FStereolabsCudaInteropD3D12();
+
+	virtual void UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
+
+private:
+	cudaExternalMemory_t CudaExternalMemory;
+	cudaMipmappedArray_t CudaMipmappedArray;
+
+	// On D3D12, to interop we need a texture created with TexCreate_Shared flag.
+	// This cannot be done with a UTexture2D - instead we need a staging texture
+	FTextureRHIRef CudaInteropStagingTexture;
+
+	bool bOutputTextureSupportsInterop = false;
+	FTextureRHIRef OutputTexture;
+};
+
+class FStereolabsCudaInteropSyncPointD3D12 final : public IStereolabsCudaInteropSyncPoint
+{
+public:
+	FStereolabsCudaInteropSyncPointD3D12();
+	~FStereolabsCudaInteropSyncPointD3D12();
+
+	virtual void SyncCudaToGraphics(TArrayView<const IStereolabsCudaInterop*> Resources, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
+	virtual void SyncGraphicsToCuda(TArrayView<const IStereolabsCudaInterop*> Resources, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
+
+private:
+	TRefCountPtr<class ID3D12Fence> Fence;
+	cudaExternalSemaphore_t CudaExternalSemaphore;
+	uint64 FenceValue;
+};

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.h
@@ -72,8 +72,8 @@ public:
 	virtual void UpdateTexture(void* Mat, FRHICommandListImmediate& RHICmdList, cudaStream_t Stream) override;
 
 private:
-	cudaExternalMemory_t CudaExternalMemory;
-	cudaMipmappedArray_t CudaMipmappedArray;
+	cudaExternalMemory_t CudaExternalMemory = nullptr;
+	cudaMipmappedArray_t CudaMipmappedArray = nullptr;
 
 	// On D3D12, to interop we need a texture created with TexCreate_Shared flag.
 	// This cannot be done with a UTexture2D - instead we need a staging texture
@@ -94,6 +94,6 @@ public:
 
 private:
 	TRefCountPtr<class ID3D12Fence> Fence;
-	cudaExternalSemaphore_t CudaExternalSemaphore;
+	cudaExternalSemaphore_t CudaExternalSemaphore = nullptr;
 	uint64 FenceValue;
 };

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsCudaInterop.h
@@ -51,7 +51,7 @@ public:
 	cudaGraphicsResource_t GetCudaResource() const { return CudaResource; }
 
 private:
-	cudaGraphicsResource_t CudaResource;
+	cudaGraphicsResource_t CudaResource = nullptr;
 
 };
 

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsTexture.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsTexture.cpp
@@ -4,26 +4,11 @@
 #include "StereolabsPrivatePCH.h"
 #include "Stereolabs/Public/Core/StereolabsCameraProxy.h"
 #include "Stereolabs/Public/Utilities/StereolabsMatFunctionLibrary.h"
+#include "StereolabsCudaInterop.h"
 
-#include "RHI.h"
 #include "Rendering/Texture2DResource.h"
-
-#include "ID3D11DynamicRHI.h"
-#include "D3D11RHI.h"
-#include "D3D11Util.h"
 #include "RHICommandList.h"
-#include "RHIDefinitions.h"
 
-#include "Windows/AllowWindowsPlatformTypes.h" 
-#include <cuda.h>
-#include <cuda_d3d11_interop.h>
-#include <cuda_gl_interop.h>
-#include "Windows/HideWindowsPlatformTypes.h"
-
-#include "Runtime/Launch/Resources/Version.h"
-THIRD_PARTY_INCLUDES_START
-#include <d3d12.h>
-THIRD_PARTY_INCLUDES_END
 
 DEFINE_LOG_CATEGORY(SlTexture);
 
@@ -38,41 +23,19 @@ DEFINE_LOG_CATEGORY(SlTexture);
 		SL_LOG_E(SlTexture, "Trying to update texture %s which is not created.", *Name.ToString());\
 		return;\
 	}\
-	else if (!CudaResource)\
-	{\
-		SL_LOG_E(SlTexture, "Trying to update texture %s which cuda resource is not registered.", *Name.ToString());\
-		return;\
-	}\
 
-#define CHECK_CUDA_MEMCPY(CudaError)\
-	if (CudaError != cudaSuccess)\
-	{\
-		SL_LOG_E(SlTexture, "Error while updating texture %s: %s", *Name.ToString(), *FString(cudaGetErrorString(CudaError)));\
-	}\
 
 USlTexture::USlTexture()
 	:
 	Texture(nullptr),
-	CudaResource(nullptr),
-	bCudaInteropEnabled(true)
+	bCudaInteropEnabled(false)
 {
 }
 
 void USlTexture::BeginDestroy()
 {
-	if (CudaResource)
-	{
-		if (GSlCameraProxy && GSlCameraProxy->IsCameraOpened())
-		{
-			GSlCameraProxy->PushCudaContext();
-
-			cudaGraphicsUnregisterResource(CudaResource);
-
-			GSlCameraProxy->PopCudaContext();
-		}
-
-		CudaResource = nullptr;
-	}
+	CudaInterop.Reset();
+	CudaSync.Reset();
 
 	Super::BeginDestroy();
 }
@@ -88,15 +51,11 @@ void USlTexture::BP_UpdateTexture()
 		{
 			if (bCudaInteropEnabled)
 			{
-				GSlCameraProxy->PushCudaContext();
+				check(CudaInterop && CudaSync);
 
-				cudaGraphicsMapResources(1, &CudaResource, 0);
-
+				CudaSync->SyncCudaToGraphics(CudaInterop.Get(), RHICmdList, nullptr);
 				UpdateTexture();
-
-				cudaGraphicsUnmapResources(1, &CudaResource, 0);
-
-				GSlCameraProxy->PopCudaContext();
+				CudaSync->SyncGraphicsToCuda(CudaInterop.Get(), RHICmdList, nullptr);
 			}
 			else
 			{
@@ -117,15 +76,11 @@ void USlTexture::BP_UpdateTextureWithMat(const FSlMat& NewMat)
 		{
 			if (bCudaInteropEnabled)
 			{
-				GSlCameraProxy->PushCudaContext();
+				check(CudaInterop && CudaSync);
 
-				cudaGraphicsMapResources(1, &CudaResource, 0);
-
+				CudaSync->SyncCudaToGraphics(CudaInterop.Get(), RHICmdList, nullptr);
 				UpdateTexture(NewMat);
-
-				cudaGraphicsUnmapResources(1, &CudaResource, 0);
-
-				GSlCameraProxy->PopCudaContext();
+				CudaSync->SyncGraphicsToCuda(CudaInterop.Get(), RHICmdList, nullptr);
 			}
 			else
 			{
@@ -137,78 +92,18 @@ void USlTexture::BP_UpdateTextureWithMat(const FSlMat& NewMat)
 
 void USlTexture::UpdateTexture()
 {
-	if (!Mat.Mat) return;
-
-	if (!bCudaInteropEnabled)
-	{
-		sl_mat_update_cpu_from_gpu(Mat.Mat);
-		void* MatPtr = sl_mat_get_ptr(Mat.Mat, SL_MEM_CPU);
-
-		SL_MAT_TYPE mat_type = sl::unreal::GetSlMatTypeFormatFromSlTextureFormat(TextureFormat);
-		int ByteSize = sl::unreal::GetSizeInBytes(mat_type);
-
-		FUpdateTextureRegion2D region = FUpdateTextureRegion2D(0, 0, 0, 0, Width, Height);
-
-		FTexture2DResource* resource = (FTexture2DResource*)Texture->GetResource();
-		RHIUpdateTexture2D(resource->GetTexture2DRHI(), 0, region, region.Width * ByteSize, (uint8*)MatPtr);
-	}
-	else
-	{
-#if WITH_EDITOR
-		CHECK_UPDATE_VALID();
-#endif
-
-		cudaArray_t TransitionArray = nullptr;
-		SL_MEM MemType = (SL_MEM)sl_mat_get_memory_type(Mat.Mat);
-
-		cudaGraphicsSubResourceGetMappedArray(&TransitionArray, CudaResource, 0, 0);
-		cudaError_t CudaError = cudaError::cudaErrorInvalidTexture;
-		CudaError = cudaMemcpy2DToArray(TransitionArray, 0, 0, sl_mat_get_ptr(Mat.Mat, MemType), sl_mat_get_step_bytes(Mat.Mat, MemType), sl_mat_get_width_bytes(Mat.Mat), sl_mat_get_height(Mat.Mat), cudaMemcpyDeviceToDevice);
-
-#if WITH_EDITOR
-		CHECK_CUDA_MEMCPY(CudaError)
-#endif
-	}
+	UpdateTexture(Mat.Mat);
 }
 
 void USlTexture::UpdateTexture(const FSlMat& NewMat)
 {
-	if (!NewMat.Mat) return;
-
-	if (!bCudaInteropEnabled)
-	{
-		sl_mat_update_cpu_from_gpu(NewMat.Mat);
-		void* MatPtr = sl_mat_get_ptr(NewMat.Mat, SL_MEM_CPU);
-
-		SL_MAT_TYPE mat_type = sl::unreal::GetSlMatTypeFormatFromSlTextureFormat(TextureFormat);
-		int ByteSize = sl::unreal::GetSizeInBytes(mat_type);
-
-		FUpdateTextureRegion2D region = FUpdateTextureRegion2D(0, 0, 0, 0, Width, Height);
-
-		FTexture2DResource* resource = (FTexture2DResource*)Texture->GetResource();
-		RHIUpdateTexture2D(resource->GetTexture2DRHI(), 0, region, region.Width * ByteSize, (uint8*)MatPtr);
-	}
-	else
-	{
-#if WITH_EDITOR
-		CHECK_UPDATE_VALID();
-#endif
-
-		cudaArray_t TransitionArray = nullptr;
-		SL_MEM MemType = (SL_MEM)sl_mat_get_memory_type(NewMat.Mat);
-		cudaGraphicsSubResourceGetMappedArray(&TransitionArray, CudaResource, 0, 0);
-
-		cudaError_t CudaError = cudaError::cudaErrorInvalidTexture;
-		CudaError = cudaMemcpy2DToArray(TransitionArray, 0, 0, sl_mat_get_ptr(NewMat.Mat, MemType), sl_mat_get_step_bytes(NewMat.Mat, MemType), sl_mat_get_width_bytes(NewMat.Mat), sl_mat_get_height(NewMat.Mat), cudaMemcpyDeviceToDevice);
-
-#if WITH_EDITOR
-		CHECK_CUDA_MEMCPY(CudaError)
-#endif
-	}
+	UpdateTexture(NewMat.Mat);
 }
 
 void USlTexture::UpdateTexture(void* NewMat)
 {
+	check(IsInRenderingThread());
+
 	if (!NewMat) return;
 
 	if (!bCudaInteropEnabled)
@@ -231,15 +126,8 @@ void USlTexture::UpdateTexture(void* NewMat)
 		CHECK_UPDATE_VALID();
 #endif
 
-		cudaArray_t TransitionArray = nullptr;
-		cudaGraphicsSubResourceGetMappedArray(&TransitionArray, CudaResource, 0, 0);
-		SL_MEM MemType = (SL_MEM)sl_mat_get_memory_type(NewMat);
-		cudaError_t CudaError = cudaError::cudaErrorInvalidTexture;
-		CudaError = cudaMemcpy2DToArray(TransitionArray, 0, 0, sl_mat_get_ptr(NewMat, MemType), sl_mat_get_step_bytes(NewMat, MemType), sl_mat_get_width_bytes(NewMat), sl_mat_get_height(NewMat), cudaMemcpyDeviceToDevice);
-
-#if WITH_EDITOR
-		CHECK_CUDA_MEMCPY(CudaError)
-#endif
+		check(CudaInterop);
+		CudaInterop->UpdateTexture(NewMat, FRHICommandListExecutor::GetImmediateCommandList(), nullptr);
 	}
 }
 
@@ -267,15 +155,7 @@ bool USlTexture::Resize(int32 NewWidth, int32 NewHeight)
 		Texture->ConditionalBeginDestroy();
 		Texture = nullptr;
 
-		if (CudaResource)
-		{
-			if (GSlCameraProxy && GSlCameraProxy->IsCameraOpened())
-			{
-				cudaGraphicsUnregisterResource(CudaResource);
-			}
-
-			CudaResource = nullptr;
-		}
+		CudaInterop.Reset();
 
 		InitResources(TextureFormat, Compression);
 	}
@@ -361,8 +241,10 @@ USlMeasureTexture* USlMeasureTexture::CreateMeasureTexture(const FName& TextureN
 void USlTexture::InitResources(ESlTextureFormat Format, TextureCompressionSettings Compression)
 {
 	TextureFormat = Format;
+	EPixelFormat PixelFormat = GetPixelFormatFromSlTextureFormat(Format);
+
 	// Create texture
-	Texture = UTexture2D::CreateTransient(Width, Height, GetPixelFormatFromSlTextureFormat(Format));
+	Texture = UTexture2D::CreateTransient(Width, Height, PixelFormat);
 #if WITH_EDITORONLY_DATA
 	Texture->MipGenSettings = TextureMipGenSettings::TMGS_NoMipmaps;
 	Texture->CompressionNone = true;
@@ -382,38 +264,19 @@ void USlTexture::InitResources(ESlTextureFormat Format, TextureCompressionSettin
 	FlushRenderingCommands();
 
 	FString RHIName = GDynamicRHI->GetName();
-
 	if (RHIName.Equals("D3D11"))
 	{
-		GSlCameraProxy->PushCudaContext();
+		CudaInterop = MakeShared<FStereolabsCudaInteropD3D11>(Texture->GetResource()->TextureRHI);
+		CudaSync = MakeShared<FStereolabsCudaInteropSyncPointD3D11>();
 
-		cudaError_t CudaError = cudaError::cudaSuccess;
-
-		// This function has changed between 5.0 and 5.1.
-#if ENGINE_MINOR_VERSION == 0		// 5.0
-		FD3D11TextureBase* D3D11Texture = GetD3D11TextureFromRHITexture(Texture->Resource->TextureRHI);
-#elif ENGINE_MINOR_VERSION == 1		// 5.1
-		FD3D11Texture* D3D11Texture = GetD3D11TextureFromRHITexture(Texture->Resource->TextureRHI);
-#else								// 5.2
-		ID3D11Resource* D3D11NativeTexture = GetID3D11DynamicRHI()->RHIGetResource(Texture->GetResource()->TextureRHI);
-#endif
-
-#if ENGINE_MINOR_VERSION >= 2
-		CudaError = cudaGraphicsD3D11RegisterResource(&CudaResource, D3D11NativeTexture, cudaGraphicsMapFlagsNone);
-#else
-		CudaError = cudaGraphicsD3D11RegisterResource(&CudaResource, D3D11Texture->GetResource(), cudaGraphicsMapFlagsNone);
-#endif
-
-		GSlCameraProxy->PopCudaContext();
-
-		if (CudaError != cudaError::cudaSuccess)
-		{
-			SL_LOG_E(SlTexture, "Error while registering resource %s: %s", *Name.ToString(), *FString(cudaGetErrorString(CudaError)));
-		}
+		bCudaInteropEnabled = true;
 	}
 	else if (RHIName.Equals("D3D12"))
 	{
-		bCudaInteropEnabled = false; // Cuda interop is not available with DX12
+		CudaInterop = MakeShared<FStereolabsCudaInteropD3D12>(Texture->GetResource()->TextureRHI);
+		CudaSync = MakeShared<FStereolabsCudaInteropSyncPointD3D12>();
+
+		bCudaInteropEnabled = true;
 	}
 	else
 	{

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsTexture.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsTexture.cpp
@@ -150,11 +150,12 @@ bool USlTexture::Resize(int32 NewWidth, int32 NewHeight)
 	Height = NewHeight;
 	if (MemoryType == ESlMemoryType::MT_GPU && Texture)
 	{
+        FlushRenderingCommands();
 		TextureCompressionSettings Compression = Texture->CompressionSettings;
 
 		Texture->ConditionalBeginDestroy();
 		Texture = nullptr;
-
+CudaInterop.Reset();
 		CudaInterop.Reset();
 
 		InitResources(TextureFormat, Compression);

--- a/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsTextureBatch.cpp
+++ b/Plugins/Stereolabs/Source/Stereolabs/Private/Core/StereolabsTextureBatch.cpp
@@ -4,6 +4,7 @@
 #include "StereolabsPrivatePCH.h"
 #include "Stereolabs/Public/Core/StereolabsCoreUtilities.h"
 #include "Stereolabs/Public/Core/StereolabsCameraProxy.h"
+#include "StereolabsCudaInterop.h"
 
 DEFINE_LOG_CATEGORY(SlTextureBatch);
 
@@ -69,6 +70,8 @@ void USlTextureBatch::BeginDestroy()
 		GSlCameraProxy->OnGrabThreadEnabled.RemoveDynamic(this, &USlTextureBatch::SetAsyncRetrieveEnabled);
 	}
 
+	CudaSync.Reset();
+
 	Super::BeginDestroy();
 }
 
@@ -88,7 +91,20 @@ USlTextureBatch* USlTextureBatch::CreateTextureBatch(const FName& Name, ESlMemor
 	TextureBatch->Name = Name;
 
 	FString RHIName = GDynamicRHI->GetName();
-	TextureBatch->bCudaInteropEnabled = RHIName.Equals("D3D11") ? true : false; // for the moment, cuda interop is only available with dx11
+	if (RHIName.Equals("D3D11"))
+	{
+		TextureBatch->CudaSync = MakeShared<FStereolabsCudaInteropSyncPointD3D11>();
+		TextureBatch->bCudaInteropEnabled = true;
+	}
+	else if (RHIName.Equals("D3D12"))
+	{
+		TextureBatch->CudaSync = MakeShared<FStereolabsCudaInteropSyncPointD3D12>();
+		TextureBatch->bCudaInteropEnabled = true;
+	}
+	else
+	{
+		TextureBatch->bCudaInteropEnabled = false;
+	}
 
 	GSlCameraProxy->OnGrabThreadEnabled.AddDynamic(TextureBatch, &USlTextureBatch::SetAsyncRetrieveEnabled);
 
@@ -346,7 +362,7 @@ void USlGPUTextureBatch::AddTexture(USlTexture* Texture)
 
 	// Synchronize if async retrieve
 	SL_SCOPE_LOCK(Lock, RetrieveSection)
-		CudaResourcesPool.AddUnique(Texture->CudaResource);
+		CudaResources.AddUnique(Texture->GetCudaInterop());
 		TexturesPool.AddUnique(Texture);
 
 		SL_SCOPE_LOCK(SubLock, BuffersSection)
@@ -369,7 +385,7 @@ void USlGPUTextureBatch::RemoveTexture(USlTexture* Texture)
 
 	// Synchronize if async retrieve
 	SL_SCOPE_LOCK(Lock, RetrieveSection)
-		CudaResourcesPool.RemoveSingle(Texture->CudaResource);
+		CudaResources.RemoveSingle(Texture->GetCudaInterop());
 		TexturesPool.RemoveSingle(Texture);
 
 		SL_SCOPE_LOCK(SubLock, BuffersSection)
@@ -391,7 +407,7 @@ void USlGPUTextureBatch::Clear()
 
 	// Synchronize if async retrieve
 	SL_SCOPE_LOCK(Lock, RetrieveSection)
-		CudaResourcesPool.Empty();
+		CudaResources.Empty();
 		TexturesPool.Empty();
 
 		SL_SCOPE_LOCK(SubLock, BuffersSection)
@@ -462,13 +478,9 @@ bool USlGPUTextureBatch::Tick()
 		ENQUEUE_RENDER_COMMAND(TickGPUBatch)(
 			[this](FRHICommandListImmediate& RHICmdList)
 			{
-				int32 BatchSize = TexturesPool.Num();
-
 				if (bCudaInteropEnabled)
 				{
-					GSlCameraProxy->PushCudaContext();
-
-					cudaGraphicsMapResources(BatchSize, CudaResourcesPool.GetData(), 0);
+					CudaSync->SyncCudaToGraphics(CudaResources, RHICmdList, nullptr);
 
 					for (auto TextureIt = TexturesPool.CreateIterator(); TextureIt; ++TextureIt)
 					{
@@ -486,9 +498,7 @@ bool USlGPUTextureBatch::Tick()
 						}		
 					}
 
-					cudaGraphicsUnmapResources(BatchSize, CudaResourcesPool.GetData(), 0);
-
-					GSlCameraProxy->PopCudaContext();
+					CudaSync->SyncGraphicsToCuda(CudaResources, RHICmdList, nullptr);
 				}
 				else
 				{
@@ -531,22 +541,16 @@ bool USlGPUTextureBatch::Tick()
 		ENQUEUE_RENDER_COMMAND(TickGPUBatchAsyncRetrieve)(
 			[this, &Buffer = *Buffers[1]](FRHICommandListImmediate& RHICmdList)
 			{
-				int32 BatchSize = TexturesPool.Num();
-
 				if (bCudaInteropEnabled)
 				{
-					GSlCameraProxy->PushCudaContext();
-
-					cudaGraphicsMapResources(BatchSize, CudaResourcesPool.GetData(), 0);
+					CudaSync->SyncCudaToGraphics(CudaResources, RHICmdList, nullptr);
 
 					for (auto TextureIt = TexturesPool.CreateIterator(); TextureIt; ++TextureIt)
 					{
 						(*TextureIt)->UpdateTexture(Buffer.Mats[TextureIt.GetIndex()]);
 					}
 
-					cudaGraphicsUnmapResources(BatchSize, CudaResourcesPool.GetData(), 0);
-
-					GSlCameraProxy->PopCudaContext();
+					CudaSync->SyncGraphicsToCuda(CudaResources, RHICmdList, nullptr);
 				}
 				else
 				{

--- a/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsTexture.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsTexture.h
@@ -66,17 +66,23 @@ public:
 
 	/*
 	 * Update the UE texture. Must be called from rendering thread, only for GPU texture.
+	 * If CUDA interop is enabled, then synchronization between CUDA context and Graphics API must be performed
+	 * before and after calling this function. This can be done either by using a TextureBatch or calling BP_UpdateTexture from the game thread.
 	 */
 	void UpdateTexture();
 
 	/*
 	 * Update the UE texture. Must be called from rendering thread, only for GPU texture.
+	 * If CUDA interop is enabled, then synchronization between CUDA context and Graphics API must be performed
+	 * before and after calling this function. This can be done either by using a TextureBatch or calling BP_UpdateTexture from the game thread.
 	 * @param NewMat The mat used to update
 	 */
 	void UpdateTexture(const FSlMat& NewMat);
 
 	/*
 	 * Update the UE texture. Must be called from rendering thread, only for GPU texture.
+	 * If CUDA interop is enabled, then synchronization between CUDA context and Graphics API must be performed
+	 * before and after calling this function. This can be done either by using a TextureBatch or calling BP_UpdateTexture from the game thread.
 	 * @param NewMat The mat used to update if different from that owning by the texture
 	 */
 	void UpdateTexture(void* NewMat);
@@ -88,6 +94,12 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Stereolabs|Texture")
 	bool Resize(int32 NewWidth, int32 NewHeight);
+
+	/*
+	 * An IStereolabsCudaInterop object is responsible for managing shared resources between CUDA and the graphics API
+	 * Access to the interop object is needed by the texture batch to perform pre- and post- update synchronization.
+	 */
+	class IStereolabsCudaInterop* GetCudaInterop() const { return CudaInterop.Get(); }
 
 protected:
 	/*
@@ -118,12 +130,12 @@ public:
 	UPROPERTY(BlueprintReadOnly)
 	FName Name;
 
-public:
-	/** Cuda resource used for copying from SDK to render API */
-	cudaGraphicsResource_t CudaResource;
-
-	bool bCudaInteropEnabled;
 protected:
+	bool bCudaInteropEnabled;
+
+	TSharedPtr<class IStereolabsCudaInterop> CudaInterop;
+	TSharedPtr<class IStereolabsCudaInteropSyncPoint> CudaSync;
+
 	/** Type of memory used to access the texture */
 	ESlMemoryType MemoryType;
 

--- a/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsTextureBatch.h
+++ b/Plugins/Stereolabs/Source/Stereolabs/Public/Core/StereolabsTextureBatch.h
@@ -137,6 +137,12 @@ protected:
 private:
 	/** True to automatically add this batch to the OnGrabThreadEnabled delegate */
 	bool bIsAutoAddToGrabDelegate;
+
+protected:
+	// Collection of all cuda resources that are required to be synchronized upon update
+	TArray<const IStereolabsCudaInterop*> CudaResources;
+	// Only created and used by GPU texture batches when cuda interop is available
+	TSharedPtr<IStereolabsCudaInteropSyncPoint> CudaSync;
 };
 
 
@@ -190,10 +196,6 @@ private:
 	 * @param bEnabled True to enable
 	 */
 	virtual void SetAsyncRetrieveEnabled(bool bEnabled) override;
-
-private:
-	/** Pool of CUDA resources associated with textures */
-	TArray<cudaGraphicsResource_t> CudaResourcesPool;
 };
 
 /*


### PR DESCRIPTION
Included in this pull request:
- A CUDA interop abstraction layer to handle interop between CUDA and graphics APIs for updating SlTextures.
- Re-implemented the existing D3D11-CUDA interop via this abstraction layer.
- Additionally implemented D3D12-CUDA interop which was previously not available in this plugin.
- Also includes a bit of tidying of the `USlTexture` implementation.

Tested with engine versions:
- 5.5
- 5.6
- 5.7

Tested with SDK versions:
- 5.1
- 5.2

All interactions with CUDA are now moved into `StereolabsCudaInterop.h/cpp`. This splits interop into two sections: shared resource (`IStereolabsCudaInterop`), and synchronization (`IStereolabsCudaInteropSyncPoint`). This is done so that synchronization can be performed at the texture batch granularity rather than per-texture (as per the D3D11 implementation). CUDA context management is also handled internally, instead of within the `USlTexture`/`USlTextureBatch`.

Unfortunately, D3D12-CUDA interop requires an additional GPU-GPU texture copy. This is because Unreal Engine offers no way to create a `UTexture2D` with the `TexCreate_Shared` flag, which is required to use a D3D12 resource for CUDA interop. My solution was a staging texture created with the `TexCreate_Shared` flag and an additional texture copy. Should Unreal Engine introduce a way to create `UTexture`'s with custom create flags, then the `IStereolabsCudaInteropD3D12` implementation can be updated without modification to the interface (I also attempted creating a class deriving from `UTexture2D` and `FTexture2DResource`, however this runs into unavoidable linker errors. I decided CUDA-D3D12 interop was still worthwhile even with the cost of an additional GPU-GPU texture copy).

The only change of note to the external API is the removal of `cudaGraphicsResource_t CudaResource;` from `USlTexture`'s public members - but this generally is only really of internal relevance anyway (and only available when running with D3D11. If the CUDA graphics resource is required, it is accessible via the `FStereolabsCudaInteropD3D11` object). 

One other thing to note is `USlTexture::UpdateTexture` (all overloads) require CUDA/Graphics API synchronization before and after calling. This was also the case with the previous D3D11 CUDA interop implementation, and is not an issue if texture updates are performed through a texture batch or `USlTexture::BP_UpdateTexture`. I would suggest that `USlTexture::UpdateTexture` is renamed to `USlTexture::UpdateTexture_RenderThread` and made to be a protected member function to prevent misuse.